### PR TITLE
refactor : CustomException 생성

### DIFF
--- a/server1/src/main/java/sinhan/server1/global/exception/CustomException.java
+++ b/server1/src/main/java/sinhan/server1/global/exception/CustomException.java
@@ -1,0 +1,12 @@
+package sinhan.server1.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/server1/src/main/java/sinhan/server1/global/exception/CustomExceptionHandler.java
+++ b/server1/src/main/java/sinhan/server1/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,31 @@
+package sinhan.server1.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return ErrorResponse.toResponseEntity(e);
+    }
+
+    // bean validation 관련 에러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        FieldError fieldError = e.getFieldError();
+
+        log.info(fieldError.toString());
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, fieldError);
+    }
+
+
+}

--- a/server1/src/main/java/sinhan/server1/global/exception/ErrorCode.java
+++ b/server1/src/main/java/sinhan/server1/global/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package sinhan.server1.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/server1/src/main/java/sinhan/server1/global/exception/ErrorResponse.java
+++ b/server1/src/main/java/sinhan/server1/global/exception/ErrorResponse.java
@@ -1,0 +1,54 @@
+package sinhan.server1.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final String status;
+    private final String error;
+
+    //CustomException 인 경우
+    public static ResponseEntity<ErrorResponse> toResponseEntity(CustomException e){
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(
+                        ErrorResponse.builder()
+                                .status(errorCode.getStatus().name())
+                                .error(errorCode.getMessage())
+                                .build()
+                );
+
+    }
+
+    //FieldError인 경우
+    public static ResponseEntity<ErrorResponse> toResponseEntity(HttpStatus status, FieldError fieldError){
+        return ResponseEntity
+                .status(status)
+                .body(
+                        ErrorResponse.builder()
+                                .status(status.name())
+                                .error(fieldError.getDefaultMessage())
+                                .build()
+                );
+    }
+
+    //예외메세지 필요 없는 경우
+    public static ResponseEntity<ErrorResponse> toResponseEntity(HttpStatus status) {
+        return ResponseEntity
+                .status(status)
+                .body(
+                        ErrorResponse.builder()
+                                .status(status.name())
+                                .build()
+                );
+    }
+
+
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #5 

## 📌 작업 내용
사용자 정의 예외 처리를 위한 CustomException 생성
- ErrorCode : 개발자가 정의해놓은 에러코드 모아놓은 곳
- ErrorResponse : 예외 응답 일관성있게 보내기 위해 형식 만들어놓음
- CustomException : RuntimeException을 상속하여 구현
- CustomExceptionHandler : 발생한 예외를 전역적으로 처리하고 적절한 응답을 생성

예외 상황 발생시 CustomException에 에러코드를 담아 생성해주면, CustomExceptionHandler가 예외 상황을 파악하고 ErrorCode 참조해서 상태코드랑 메세지를 적절하게 ErrorResponse에 담아서 사용자에게 반환해줌

## 📚 기타
- orElseThrow가 필요하다는 생각에 만들어뒀는데 ApiResult의 Error랑 차이점을 잘 모르겠음..... 나중에 바꿔야 할듯? 
- ApiResult의 Error가 FieldError를 잡는데 사용된다고 했는데 CustomException에서도 FieldError처리하는게 있어서 차이점을 명확히 모르겠어서 뭘 살려둬야 할지 모르겠음
